### PR TITLE
dracut: add early dracut module

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,6 +70,18 @@ Method 2: systemd unit
 2. Run ``systemctl daemon-reload`` as root to make systemd reload the
    configuration files.
 
+
+Method 3: dracut module
+-----------------------
+
+Check out documentation for `dracut module`_
+
+.. _dracut module: dracut/99console-solarized/README.md
+
+.. Note::
+    dracut module only applies colors to boot console,
+    you still need method 1 or 2 to apply colors to all consoles.
+
 **Bug**: It should be written in C.
 
 Choosing theme

--- a/dracut/99console-solarized/README.md
+++ b/dracut/99console-solarized/README.md
@@ -1,0 +1,18 @@
+## installation
+
+1. copy `99console-solarized` dir into /usr/lib/dracut/modules.d
+
+
+2. module is disabled by default, to enable  
+
+  create /etc/dracut.conf.d/99-console-solarized.conf with the following contents:
+
+```bash
+add_dracutmodules+=" console-solarized "
+```
+
+3. Rebuild initrd
+
+
+
+To disable setting colors on boot one can pass `rd.solarized=off` to kernel.

--- a/dracut/99console-solarized/console-solarized-pretrigger.sh
+++ b/dracut/99console-solarized/console-solarized-pretrigger.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+
+# enable by default if found, disable if rd.solarized=0/off/no
+if type console-solarized >/dev/null && getargbool 1 rd.solarized; then
+
+	# make sure console is ready
+	udevadm trigger --action=add --subsystem-match=tty >/dev/null 2>&1
+	udevadm settle --timeout=180 2>&1 | vinfo
+
+	# get the console device
+	read consoledev rest < /sys/class/tty/console/active
+	consoledev="${consoledev:-tty0}"
+
+	if [ -c "/dev/${consoledev}" ]; then
+
+		if [ -x /lib/udev/console_init ]; then
+			/lib/udev/console_init "/dev/${consoledev}"
+		fi
+
+		console-solarized > "/dev/${consoledev}" | vinfo
+	fi
+
+fi

--- a/dracut/99console-solarized/module-setup.sh
+++ b/dracut/99console-solarized/module-setup.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# called by dracut
+check() {
+    require_binaries console-solarized || return 1
+    # don't enable by default
+    return 255
+}
+
+# called by dracut
+depends() {
+    return 0
+}
+
+# called by dracut
+install() {
+	inst /etc/console-solarized.conf
+	dracut_install console-solarized
+
+	# plymouth runs at 10, we want to run a bit later.
+	inst_hook pre-trigger 11 "${moddir}/console-solarized-pretrigger.sh"
+}


### PR DESCRIPTION
Hi!

Not sure if arch uses `dracut`, but many other distros do.

This is probably the eraliest possible way of setting color.
It installs a console init hook same way `plymouth` does and applies
colors very early.

Users still need `systemd` unit or `/etc/issue`, since `dracut` only
applies theme to boot console.