### PR TITLE
Don't fail when tty device is missing

### DIFF
--- a/console-solarized@.service
+++ b/console-solarized@.service
@@ -16,6 +16,7 @@ Description=Solarized color palette for the Linux console
 Documentation=https://github.com/adeverteuil/console-solarized
 Documentation=http://ethanschoonover.com/solarized
 After=getty@%i.service
+ConditionPathExists=/dev/%i
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
When running in a container, `console-solarized@.service` will fail due to a missing tty device with an error like the following:

```
systemd[43]: console-solarized@tty1.service: Failed to set up standard output: No such file or directory
systemd[43]: console-solarized@tty1.service: Failed at step STDOUT spawning /usr/bin/console-solarized: No such file or directory
```
This change work around the issue by adding a path condition to the systemd unit. 

With this change the systemd service will not fail, instead, it will just not start due to the condition failure, so it won't spam the log with a priority error message.

```
● console-solarized@tty1.service - Solarized color palette for the Linux console
     Loaded: loaded (/etc/systemd/system/console-solarized@.service; disabled; vendor preset: disabled)
     Active: inactive (dead)
  Condition: start condition failed at Tue 2020-10-20 23:51:30 IDT; 19min ago
             └─ ConditionPathExists=/dev/tty1 was not met
       Docs: https://github.com/adeverteuil/console-solarized
             http://ethanschoonover.com/solarized
```
 
Tested on my Arch Linux host and a systemd-nspawn container. The service still works correctly on the host after this change.

This helps with having a single system image or rootfs for both the host and the container.